### PR TITLE
Fixed the error of "TypeError: numpy boolean..." in chanvese.py

### DIFF
--- a/chanvese.py
+++ b/chanvese.py
@@ -254,7 +254,7 @@ def sussman_sign(D):
 
 # Convergence Test
 def convergence(p_mask, n_mask, thresh, c):
-    diff = p_mask - n_mask
+    diff = np.array(p_mask.astype(np.int)) - np.array(n_mask.astype(np.int))
     n_diff = np.sum(np.abs(diff))
     if n_diff < thresh:
         c = c + 1


### PR DESCRIPTION
### abstract

- fixed the error:
```
python chanvese.py
iteration: 0
Traceback (most recent call last):
  File "chanvese.py", line 271, in <module>
    chanvese(img, mask, max_its=1000, display=True, alpha=1.0)
  File "chanvese.py", line 97, in chanvese
    c = convergence(prev_mask, new_mask, thresh, c)
  File "chanvese.py", line 257, in convergence
    diff = p_mask - n_mask
TypeError: numpy boolean subtract, the `-` operator, is not supported, use the bitwise_xor, the `^` operator, or the logical_xor function instead.
```
